### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,5 +1,8 @@
 name: test build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/sngrcreative/astro-base/security/code-scanning/1](https://github.com/sngrcreative/astro-base/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` section that limits the `GITHUB_TOKEN` to the least privilege required. For this workflow, the steps only need to read repository contents (for `actions/checkout`) and do not modify GitHub resources, so `contents: read` at minimum is appropriate.

The single best fix, without changing functionality, is to add a `permissions` block at the workflow root level (top-level, alongside `name` and `on`). This will apply to all jobs in this workflow that lack their own `permissions` block, including the `build` job. Concretely, in `.github/workflows/test-build.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: test build` and the `on:` block. No new methods, imports, or other definitions are needed, as this is purely a configuration change in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
